### PR TITLE
KAI - 아이패드 앱 프로젝트 리펙토링

### DIFF
--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		D61546642BA7D933003E375A /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61546632BA7D933003E375A /* Point.swift */; };
 		D61546662BA7D94F003E375A /* RGBColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61546652BA7D94F003E375A /* RGBColor.swift */; };
 		D615466A2BA7E7C4003E375A /* RectangleModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61546692BA7E7C4003E375A /* RectangleModelFactory.swift */; };
+		D615466C2BA8989F003E375A /* Opacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D615466B2BA8989F003E375A /* Opacity.swift */; };
+		D615466E2BA92ECF003E375A /* IDGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D615466D2BA92ECF003E375A /* IDGenerator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +59,8 @@
 		D61546632BA7D933003E375A /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
 		D61546652BA7D94F003E375A /* RGBColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RGBColor.swift; sourceTree = "<group>"; };
 		D61546692BA7E7C4003E375A /* RectangleModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleModelFactory.swift; sourceTree = "<group>"; };
+		D615466B2BA8989F003E375A /* Opacity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Opacity.swift; sourceTree = "<group>"; };
+		D615466D2BA92ECF003E375A /* IDGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDGenerator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +146,7 @@
 				D61546612BA7D90F003E375A /* Size.swift */,
 				D61546632BA7D933003E375A /* Point.swift */,
 				D61546652BA7D94F003E375A /* RGBColor.swift */,
+				D615466B2BA8989F003E375A /* Opacity.swift */,
 			);
 			path = ShapeProperties;
 			sourceTree = "<group>";
@@ -151,6 +156,7 @@
 			children = (
 				D615465F2BA7D6E0003E375A /* RectangleModel.swift */,
 				D61546692BA7E7C4003E375A /* RectangleModelFactory.swift */,
+				D615466D2BA92ECF003E375A /* IDGenerator.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -287,10 +293,12 @@
 			files = (
 				D61546342BA7D07D003E375A /* DrawingViewController.swift in Sources */,
 				D61546622BA7D90F003E375A /* Size.swift in Sources */,
+				D615466E2BA92ECF003E375A /* IDGenerator.swift in Sources */,
 				D61546642BA7D933003E375A /* Point.swift in Sources */,
 				D61546662BA7D94F003E375A /* RGBColor.swift in Sources */,
 				D615466A2BA7E7C4003E375A /* RectangleModelFactory.swift in Sources */,
 				D61546602BA7D6E0003E375A /* RectangleModel.swift in Sources */,
+				D615466C2BA8989F003E375A /* Opacity.swift in Sources */,
 				D61546302BA7D07D003E375A /* AppDelegate.swift in Sources */,
 				D61546322BA7D07D003E375A /* SceneDelegate.swift in Sources */,
 			);

--- a/DrawingApp/DrawingApp.xcodeproj/xcshareddata/xcschemes/DrawingApp.xcscheme
+++ b/DrawingApp/DrawingApp.xcodeproj/xcshareddata/xcschemes/DrawingApp.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D615462B2BA7D07D003E375A"
+               BuildableName = "DrawingApp.app"
+               BlueprintName = "DrawingApp"
+               ReferencedContainer = "container:DrawingApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D61546412BA7D07F003E375A"
+               BuildableName = "DrawingAppTests.xctest"
+               BlueprintName = "DrawingAppTests"
+               ReferencedContainer = "container:DrawingApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D615464B2BA7D07F003E375A"
+               BuildableName = "DrawingAppUITests.xctest"
+               BlueprintName = "DrawingAppUITests"
+               ReferencedContainer = "container:DrawingApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D615462B2BA7D07D003E375A"
+            BuildableName = "DrawingApp.app"
+            BlueprintName = "DrawingApp"
+            ReferencedContainer = "container:DrawingApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D615462B2BA7D07D003E375A"
+            BuildableName = "DrawingApp.app"
+            BlueprintName = "DrawingApp"
+            ReferencedContainer = "container:DrawingApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DrawingApp/DrawingApp/DrawingViewController.swift
+++ b/DrawingApp/DrawingApp/DrawingViewController.swift
@@ -9,54 +9,14 @@ import UIKit
 import os
 
 class DrawingViewController: UIViewController {
-
+    
     private let logger = os.Logger(subsystem: "pro.DrawingApp.model", category: "ModelLogging")
     
     private let factory = RectangleFactory()
-    private let size = Size(width: 150, height: 120)
     
-    private let point1 = Point(x: 10, y: 200)
-    private let point2 = Point(x: 110, y: 180)
-    private let point3 = Point(x: 590, y: 90)
-    private let point4 = Point(x: 330, y: 450)
-    
-    private let rgb1 = RGBColor(red: 245, green: 0, blue: 245)
-    private let rgb2 = RGBColor(red: 43, green: 124, blue: 95)
-    private let rgb3 = RGBColor(red: 98, green: 244, blue: 15)
-    private let rgb4 = RGBColor(red: 125, green: 39, blue: 99)
-
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .green
-        
-        
-        let rect1 = factory.createRectangleModel(size: size,
-                                                 point: point1,
-                                                 backgroundColor: rgb1,
-                                                 opacity: 9)
-        logger.log(level: .info, "Rect1 \(rect1.description)")
-        
-        
-        let rect2 = factory.createRectangleModel(size: size,
-                                                 point: point2,
-                                                 backgroundColor: rgb2,
-                                                 opacity: 5)
-        logger.log(level: .info, "Rect2 \(rect2.description)")
-        
-        let rect3 = factory.createRectangleModel(size: size,
-                                                 point: point3,
-                                                 backgroundColor: rgb3,
-                                                 opacity: 7)
-        logger.log(level: .info, "Rect3 \(rect3.description)")
-        
-        let rect4 = factory.createRectangleModel(size: size,
-                                                 point: point4,
-                                                 backgroundColor: rgb4,
-                                                 opacity: 1)
-        logger.log(level: .info, "Rect4 \(rect4.description)")
-        
     }
-
-
 }
 

--- a/DrawingApp/DrawingApp/Models/IDGenerator.swift
+++ b/DrawingApp/DrawingApp/Models/IDGenerator.swift
@@ -1,0 +1,34 @@
+//
+//  IDGenerator.swift
+//  DrawingApp
+//
+//  Created by 조호근 on 3/19/24.
+//
+
+import Foundation
+
+class IDGenerator {
+    private var existingIDs = Set<String>()
+    private let characters = "abcdefghijklmnopqrstuvwxyz0123456789"
+    
+    func generateUniqueRandomID() -> String {
+        var uniqueID: String
+        repeat {
+            uniqueID = generateRandomID()
+        } while existingIDs.contains(uniqueID)
+        
+        existingIDs.insert(uniqueID)
+        return uniqueID
+    }
+    
+    private func generateRandomID() -> String {
+        var segments = [String]()
+            
+        for _ in 0..<3 {
+            let segment = (0..<3).map { _ in characters.randomElement()! }
+            segments.append(String(segment))
+        }
+        
+        return segments.joined(separator: "-")
+    }
+}

--- a/DrawingApp/DrawingApp/Models/RectangleModel.swift
+++ b/DrawingApp/DrawingApp/Models/RectangleModel.swift
@@ -12,19 +12,41 @@ class RectangleModel {
     private var size: Size
     private var point: Point
     private var backgroundColor: RGBColor
-    private var opacity: Int
-
-    init(uniqueID: String, size: Size, point: Point, backgroundColor: RGBColor, opacity: Int) {
+    private var opacity: Opacity
+    
+    init(uniqueID: String, size: Size, point: Point, backgroundColor: RGBColor, opacity: Opacity) {
         self.uniqueID = uniqueID
         self.size = size
         self.point = point
         self.backgroundColor = backgroundColor
-        self.opacity = max(1, min(10, opacity))
+        self.opacity = opacity
     }
 }
 
 extension RectangleModel: CustomStringConvertible {
     var description: String {
-        return "(\(uniqueID)), X:\(point.x),Y:\(point.y), W\(size.width), H:\(size.height), R:\(backgroundColor.red), G:\(backgroundColor.green), B:\(backgroundColor.blue), Alpha: \(opacity)"
+        return "(\(uniqueID)), X:\(point.x),Y:\(point.y), W\(size.width), H:\(size.height), R:\(backgroundColor.red), G:\(backgroundColor.green), B:\(backgroundColor.blue), Alpha: \(opacity.value)"
     }
+    
+#if DEBUG
+    var testable_uniqueID: String {
+        return self.uniqueID
+    }
+    
+    var testable_size: Size {
+        return self.size
+    }
+    
+    var testable_point: Point {
+        return self.point
+    }
+    
+    var testable_backgroundColor: RGBColor {
+        return self.backgroundColor
+    }
+    
+    var testable_opacity: Opacity {
+        return self.opacity
+    }
+#endif
 }

--- a/DrawingApp/DrawingApp/Models/RectangleModelFactory.swift
+++ b/DrawingApp/DrawingApp/Models/RectangleModelFactory.swift
@@ -8,24 +8,14 @@
 import Foundation
 
 protocol RectangleModelFactoryProtocol {
-    func createRectangleModel(size: Size, point: Point, backgroundColor: RGBColor, opacity: Int) -> RectangleModel
+    func createRectangleModel(size: Size, point: Point, backgroundColor: RGBColor, opacity: Opacity) -> RectangleModel
 }
 
 class RectangleFactory: RectangleModelFactoryProtocol {
-    func createRectangleModel(size: Size, point: Point, backgroundColor: RGBColor, opacity: Int) -> RectangleModel {
-        let uniqueID = generateRandomID()
-        return RectangleModel(uniqueID: uniqueID, size: size, point: point, backgroundColor: backgroundColor, opacity: opacity)
-    }
+    private let idGenerator = IDGenerator()
     
-    private func generateRandomID() -> String {
-        let characters = "abcdefghijklmnopqrstuvwxyz0123456789"
-        var segments = [String]()
-        
-        for _ in 0..<3 {
-            let segment = (0..<3).map { _ in characters.randomElement()! }
-            segments.append(String(segment))
-        }
-
-        return segments.joined(separator: "-")
+    func createRectangleModel(size: Size, point: Point, backgroundColor: RGBColor, opacity: Opacity) -> RectangleModel {
+        let uniqueID = idGenerator.generateUniqueRandomID()
+        return RectangleModel(uniqueID: uniqueID, size: size, point: point, backgroundColor: backgroundColor, opacity: opacity)
     }
 }

--- a/DrawingApp/DrawingApp/ShapeProperties/Opacity.swift
+++ b/DrawingApp/DrawingApp/ShapeProperties/Opacity.swift
@@ -1,0 +1,23 @@
+//
+//  Opacity.swift
+//  DrawingApp
+//
+//  Created by 조호근 on 3/19/24.
+//
+
+import Foundation
+
+struct Opacity: Equatable {
+    let value: Int
+    
+    init?(value: Int) {
+        guard (1...10).contains(value) else {
+            return nil
+        }
+        self.value = value
+    }
+    
+    static func == (lhs: Opacity, rhs: Opacity) -> Bool {
+        return lhs.value == rhs.value
+    }
+}

--- a/DrawingApp/DrawingApp/ShapeProperties/Point.swift
+++ b/DrawingApp/DrawingApp/ShapeProperties/Point.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
-struct Point {
+struct Point: Equatable {
     var x: Double
     var y: Double
+    
+    static func == (lhs: Point, rhs: Point) -> Bool {
+        return lhs.x == rhs.x && lhs.y == rhs.y
+    }
 }

--- a/DrawingApp/DrawingApp/ShapeProperties/RGBColor.swift
+++ b/DrawingApp/DrawingApp/ShapeProperties/RGBColor.swift
@@ -7,14 +7,23 @@
 
 import Foundation
 
-struct RGBColor {
+struct RGBColor: Equatable {
     var red: Int
     var green: Int
     var blue: Int
     
-    init(red: Int, green: Int, blue: Int) {
-        self.red = max(0, min(255, red))
-        self.green = max(0, min(255, green))
-        self.blue = max(0, min(255, blue))
+    init?(red: Int, green: Int, blue: Int) {
+        guard (0...255).contains(red),
+              (0...255).contains(green),
+              (0...255).contains(blue) else {
+            return nil
+        }
+        self.red = red
+        self.green = green
+        self.blue = blue
+    }
+    
+    static func == (lhs: RGBColor, rhs: RGBColor) -> Bool {
+        return lhs.red == rhs.red && lhs.green == rhs.green && lhs.blue == rhs.blue
     }
 }

--- a/DrawingApp/DrawingApp/ShapeProperties/Size.swift
+++ b/DrawingApp/DrawingApp/ShapeProperties/Size.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
-struct Size {
+struct Size: Equatable {
     var width: Double
     var height: Double
+    
+    static func == (lhs: Size, rhs: Size) -> Bool {
+        return lhs.width == rhs.width && lhs.height == rhs.height
+    }
 }

--- a/DrawingApp/DrawingAppTests/DrawingAppTests.swift
+++ b/DrawingApp/DrawingAppTests/DrawingAppTests.swift
@@ -6,31 +6,35 @@
 //
 
 import XCTest
+import os
 @testable import DrawingApp
 
 final class DrawingAppTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    private let logger = Logger(subsystem: "pro.DrawingApp.Tests", category: "RectangleFactoryTests")
+    private var factory: RectangleFactory!
+    
+    override func setUp() {
+        super.setUp()
+        
+        self.factory = RectangleFactory()
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    
+    func test_RectangleFactory() {
+        
+        let size = Size(width: 150, height: 120)
+        let point1 = Point(x: 10, y: 200)
+        let rgb1 = RGBColor(red: 245, green: 0, blue: 245)
+        let opacity1 = Opacity(value: 9)
+        
+        let rectangleModel = factory.createRectangleModel(size: size, point: point1, backgroundColor: rgb1!, opacity: opacity1!)
+        
+        XCTAssertNotNil(rectangleModel, "모델 객체 생성 실패")
+        XCTAssertEqual(rectangleModel.testable_size, size, "Size 속성 값 불일치")
+        XCTAssertEqual(rectangleModel.testable_point, point1, "Point 속성 값 불일치")
+        XCTAssertEqual(rectangleModel.testable_backgroundColor, rgb1, "rgb 속성 값 불일치")
+        XCTAssertEqual(rectangleModel.testable_opacity, opacity1, "Size 속성 값 불일치")
+        
+        logger.info("\(rectangleModel.description)")
     }
 
 }


### PR DESCRIPTION


### 팩토리 메소드와 생성자 init은 유사한데 왜 팩토리가 필요한가?

팩토리 메소드는 객체 생성 과정이 복잡하거나 추가적인 설정이 필요한 경우에 사용됩니다.

지금 같은 경우 고유 ID 생성하여서 객체를 생성해야 하는 경우, 추가적인 초기화 작업을 팩토리 메소드 내부에서 처리할 수 있습니다.

그래서 

- 복잡성을 관리할 수 있다. - 복잡한 코드를 클라이언트 코드에서 숨길 수 있음
- 확장성과 유지보수성 향상 - 객체의 구체적인 타입을 쉽게 바꿀 수 있다.
- 테스트가 용이하다.

### 1. Opacity 객체를 생성하여 1~10까지 검증되도록 하였습니다.

### 2. 컬러값도 초기화때 범위 안에드는지 검증을하도록 개선하였습니다.

### 3. 유니크 ID를 생성할 때 Set을 이용하여 검증하도록 개선하였습니다.

### 4. 유닛 테스트를 할 때 
사각형 모델의 객체 속성들이 private로 되어있어서, 동등한지 비교하고 싶을 때 속성에 접근을 못하여서 속성을 꺼내는 함수를 만들까하는 고민과 테스트를 위해서 접근 제어자를 바꿀려고 하는 고민 2개가 떠올랐는데 전부 배보다 배꼽이 크다고 생각되었습니다. 그래서  디버그 빌드 환경에서만 컴파일 되도록 #if DEBUG지시어를 사용하여서 test용 속성을 쓸 수 있도록 하였습니다. 이런 의도가 지금 상황에서는 적합한 방법인지 궁금합니다.